### PR TITLE
Drop support for Raspi2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,6 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          - linux/arm/v7
           - linux/arm64
     steps:
       - name: Checkout repository


### PR DESCRIPTION
cbor2 is no longer build for this architecture. It is now based on rust and packages are only available for arm64.